### PR TITLE
Use the `--deployment` flag for bundle install

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,9 +120,7 @@ You can cache the installed gems with these two steps:
         restore-keys: |
           bundle-use-ruby-${{ matrix.os }}-${{ matrix.ruby }}-
     - name: bundle install
-      run: |
-        bundle config path vendor/bundle
-        bundle install --jobs 4 --retry 3
+      run: bundle install --deployment --jobs 4
 ```
 
 When using a single OS, replace `${{ matrix.os }}` with the OS.  


### PR DESCRIPTION
`bundle install --deployment` should be used on CI environments - it sets additional options beyond the install path (ensures the Gemfile.lock is checked in, up to date, etc). https://bundler.io/v2.0/man/bundle-install.1.html#DEPLOYMENT-MODE

`bundle --retry 3` is the default and does not need to be specified. https://bundler.io/v2.0/man/bundle-config.1.html#LIST-OF-AVAILABLE-KEYS